### PR TITLE
Use python configparser

### DIFF
--- a/wazo_agid/modules/in_callerid.py
+++ b/wazo_agid/modules/in_callerid.py
@@ -7,8 +7,6 @@ import sys
 import logging
 import ConfigParser
 
-from xivo import OrderedConf
-
 from wazo_agid import agid
 
 RULES_FILE = '/etc/xivo/asterisk/xivo_in_callerid.conf'
@@ -62,7 +60,8 @@ def setup(cursor):
     global config
 
     re_objs.clear()
-    config = OrderedConf.OrderedRawConf(filename=RULES_FILE)
+    config = ConfigParser.RawConfigParser()
+    config.read([RULES_FILE])
 
     for section in config:
         try:


### PR DESCRIPTION
The python configparser is now ordered by default, no need to
use the backported hacked python 2.4 module.

See: https://www.python.org/dev/peps/pep-0372/