### PR TITLE
do not handled firstname/lastname separatly

### DIFF
--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -318,7 +318,7 @@ class TestUserFeatures(_BaseTestCase):
 
         userfeatures._set_xivo_user_name()
 
-        self.assertEqual(self._agi.set_variable.call_count, 2)
+        self.assertEqual(self._agi.set_variable.call_count, 1)
 
     def test_set_xivo_redirecting_info_full_callerid(self):
         userfeatures = UserFeatures(self._agi, self._cursor, self._args)

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -159,10 +159,11 @@ class UserFeatures(Handler):
 
     def _set_xivo_user_name(self):
         if self._user:
-            if self._user.firstname:
-                self._agi.set_variable('XIVO_DST_FIRSTNAME', self._user.firstname)
-            if self._user.lastname:
-                self._agi.set_variable('XIVO_DST_LASTNAME', self._user.lastname)
+            wazo_dst_name = '{firstname} {lastname}'.format(
+                firstname=self._user.firstname if self._user.firstname else '',
+                lastname=self._user.lastname if self._user.lastname else '',
+            )
+            self._agi.set_variable('WAZO_DST_NAME', wazo_dst_name.strip())
 
     def _set_wazo_uuid(self):
         if self._user:


### PR DESCRIPTION
reason: on forward, if the destination user has no lastname, then the
lastname of the first user is merged with the destination user

Also rename this variable and merge variable since there are no used
separately