### PR TITLE
use agentd without https by default

### DIFF
--- a/etc/wazo-agid/config.yml
+++ b/etc/wazo-agid/config.yml
@@ -28,7 +28,9 @@ listen_port: 4573
 # wazo-agentd connection informations.
 agentd:
   host: localhost
-  verify_certificate: /usr/share/xivo-certs/server.crt
+  port: 9493
+  prefix: null
+  https: false
 
 # wazo-dird connection informations.
 dird:

--- a/wazo_agid/bin/agid.py
+++ b/wazo_agid/bin/agid.py
@@ -23,6 +23,12 @@ from wazo_agid.modules import *
 
 FOREGROUND = True  # Always in foreground systemd takes care of daemonizing
 _DEFAULT_CONFIG = {
+    'agentd': {
+        'host': 'localhost',
+        'port': 9493,
+        'prefix': None,
+        'https': False,
+    },
     'dird': {
         'host': 'localhost',
         'port': 9489,


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-agentd-client/pull/7
Depends-on: https://github.com/wazo-platform/wazo-agentd/pull/22