### PR TITLE
Wazo 1854 paging fail

### DIFF
--- a/wazo_agid/modules/paging.py
+++ b/wazo_agid/modules/paging.py
@@ -37,34 +37,41 @@ def paging(agi, cursor, args):
 
     agi.set_variable('XIVO_PAGING_LINES', paging_line)
     agi.set_variable('XIVO_PAGING_TIMEOUT', paging_entry.timeout)
+    agi.set_variable('XIVO_PAGING_OPTS', build_options(paging_entry))
 
+
+def build_options(paging):
     # s = call phones only if not busy
     # b = Gosub for each destination channels
     paging_opts = 'sb(paging^add-sip-headers^1)'
 
-    if paging_entry.duplex:
+    if paging.duplex:
         paging_opts = paging_opts + 'd'
 
-    if paging_entry.quiet:
+    if paging.quiet:
         paging_opts = paging_opts + 'q'
 
-    if paging_entry.record:
+    if paging.record:
         paging_opts = paging_opts + 'r'
 
-    if paging_entry.ignore:
+    if paging.ignore:
         paging_opts = paging_opts + 'i'
 
-    if paging_entry.announcement_play and paging_entry.announcement_file:
-        announcement_file_name = os.path.join('/var/lib/wazo/sounds/tenants',
-                                              paging_entry.tenant_uuid,
-                                              'playback',
-                                              paging_entry.announcement_file)
-        paging_opts = paging_opts + 'A({file_name})'.format(file_name=announcement_file_name)
+    if paging.announcement_play and paging.announcement_file:
+        sound_file_directory='/var/lib/wazo/sounds/tenants'
+        announcement_file_name = os.path.join(
+            sound_file_directory,
+            paging.tenant_uuid,
+            'playback',
+            paging.announcement_file,
+        )
 
-    if paging_entry.announcement_caller:
+        paging_opts = paging_opts + u'A({file_name})'.format(file_name=announcement_file_name)
+
+    if paging.announcement_caller:
         paging_opts = paging_opts + 'n'
 
-    agi.set_variable('XIVO_PAGING_OPTS', paging_opts)
+    return paging_opts
 
 
 agid.register(paging)

--- a/wazo_agid/modules/paging.py
+++ b/wazo_agid/modules/paging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -54,7 +54,7 @@ def paging(agi, cursor, args):
     if paging_entry.ignore:
         paging_opts = paging_opts + 'i'
 
-    if paging_entry.announcement_play:
+    if paging_entry.announcement_play and paging_entry.announcement_file:
         announcement_file_name = os.path.join('/var/lib/wazo/sounds/tenants',
                                               paging_entry.tenant_uuid,
                                               'playback',

--- a/wazo_agid/modules/tests/test_paging.py
+++ b/wazo_agid/modules/tests/test_paging.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from mock import Mock
+from hamcrest import assert_that, equal_to
+
+from ..paging import build_options
+
+class TestPagingOptions(TestCase):
+
+    def test_build_options_nothing_set(self):
+        paging = Mock(
+            duplex=False,
+            quiet=False,
+            record=False,
+            ignore=False,
+            announcement_play=False,
+            announcement_file=None,
+            announcement_caller=False,
+        )
+
+        options = build_options(paging)
+
+        assert_that(options, equal_to('sb(paging^add-sip-headers^1)'))
+
+    def test_build_options_all(self):
+        paging = Mock(
+            duplex=True,
+            quiet=True,
+            record=True,
+            ignore=True,
+            announcement_play=True,
+            announcement_file='filename',
+            announcement_caller=True,
+            tenant_uuid='<tenant_uuid>',
+        )
+
+        options = build_options(paging)
+
+        assert_that(
+            options,
+            equal_to('sb(paging^add-sip-headers^1)dqriA(/var/lib/wazo/sounds/tenants/<tenant_uuid>/playback/filename)n'),
+        )
+
+    def test_build_options_announcement_play_no_file(self):
+        paging = Mock(
+            duplex=False,
+            quiet=False,
+            record=False,
+            ignore=False,
+            announcement_play=True,
+            announcement_file=None,
+            announcement_caller=False,
+        )
+
+        options = build_options(paging)
+
+        assert_that(options, equal_to('sb(paging^add-sip-headers^1)'))


### PR DESCRIPTION
In the paging AGI only set the `A` option if there a file to play. Otherwise the beep is heard and the call is hungup automatically.