### PR TITLE
Pull request for WAZO-1842-remove-pid

### DIFF
--- a/debian/wazo-agid.postinst
+++ b/debian/wazo-agid.postinst
@@ -32,20 +32,6 @@ case "$1" in
             rmdir --ignore-fail-on-non-empty /var/lib/xivo-agid
         fi
 
-        # move files from xivo-agid
-        if [ -f /var/log/xivo-agid.log ] ; then
-            rename 's/xivo-agid/wazo-agid/g' /var/log/xivo-agid.log*
-        fi
-        rm -rf /run/xivo-agid
-        if [ -d /etc/xivo-agid/conf.d ] ; then
-            find /etc/xivo-agid/conf.d/ -mindepth 1 -exec mv {} /etc/wazo-agid/conf.d/ \;
-            rmdir --ignore-fail-on-non-empty -p /etc/xivo-agid/conf.d
-        fi
-        if getent passwd xivo-agid > /dev/null; then
-            deluser --quiet --system --remove-home xivo-agid
-        fi
-        # End of move files from xivo-agid
-
         # setup permissions for the log file
         if [ ! -e "$LOG_FILENAME" ]; then
             touch "$LOG_FILENAME"

--- a/debian/wazo-agid.service
+++ b/debian/wazo-agid.service
@@ -2,12 +2,13 @@
 Description=wazo-agid server
 ConditionPathExists=!/var/lib/wazo/disabled
 After=network.target postgresql.service
-Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
-ExecStartPre=/usr/bin/install -d -o wazo-agid -g wazo-agid /run/wazo-agid
 ExecStart=/usr/bin/wazo-agid
-PIDFile=/run/wazo-agid/wazo-agid.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/wazo-agid/config.yml
+++ b/etc/wazo-agid/config.yml
@@ -15,9 +15,6 @@ debug: false
 # Log file.
 logfile: /var/log/wazo-agid.log
 
-# PID file.
-pidfile: /run/wazo-agid/wazo-agid.pid
-
 # Database connection informations.
 db_uri: postgresql://asterisk:proformatique@localhost/asterisk
 


### PR DESCRIPTION
## remove usage of PID file and use systemd options

reason: systemd restart remove monit usage based on pid file

## debian: remove old migration code