### PR TITLE
[WAZO-1904] Define if the media call is video

### DIFF
--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -71,6 +71,7 @@ class UserFeatures(Handler):
         self._set_mobile_number()
         self._set_vmbox_lang()
         self._set_path(UserFeatures.PATH_TYPE, self._user.id)
+        self._is_video_call()
 
     def _set_members(self):
         self._userid = self._agi.get_variable(dialplan_variables.USERID)
@@ -474,3 +475,9 @@ class UserFeatures(Handler):
             return True
 
         return False
+
+    def _is_video_call(self):
+        self._agi.set_variable('WAZO_VIDEO_CALL', False)
+        video = self._agi.get_variable('CHANNEL(videonativeformat)')
+        if not 'nothing' in video:
+            self._agi.set_variable('WAZO_VIDEO_CALL', True)

--- a/wazo_agid/modules/wake_mobile.py
+++ b/wazo_agid/modules/wake_mobile.py
@@ -11,7 +11,8 @@ def wake_mobile(agi, cursor, args):
         return
 
     user_uuid = agi.get_variable('WAZO_DST_UUID')
-    agi.appexec('UserEvent', 'Pushmobile,WAZO_DST_UUID: {}'.format(user_uuid))
+    video = agi.get_variable('WAZO_VIDEO_CALL')
+    agi.appexec('UserEvent', 'Pushmobile,WAZO_DST_UUID: {},WAZO_VIDEO_CALL: {}'.format(user_uuid, video))
 
 
 agid.register(wake_mobile)


### PR DESCRIPTION
We want to know is a call is video or not. In the push notification environnement, we don't know the status of the call because it's asynchronous with the media server, so we want to give the capacity to send this information.