### PR TITLE
WAZO-2059-refactor-online-call-record

### DIFF
--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -121,7 +121,7 @@ class OutgoingFeatures(Handler):
             'tenant_uuid': self._tenant_uuid,
         }
         callrecordfile = self._call_recording_name_generator.generate(args)
-        self._agi.set_variable(dialplan_variables.CALL_RECORD_FILE_NAME, callrecordfile)
+        self._agi.set_variable('__XIVO_CALLRECORDFILE', callrecordfile)
 
     def _set_preprocess_subroutine(self):
         if self.outcall.preprocess_subroutine:

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -111,13 +111,6 @@ class OutgoingFeatures(Handler):
         self._agi.set_variable('WAZO_CALL_RECORD_ENABLED', '1' if self.callrecord else '0')
 
     def _set_record_file_name(self):
-        callrecordfile = self._build_call_record_file_name() or ''
-        self._agi.set_variable(dialplan_variables.CALL_RECORD_FILE_NAME, callrecordfile)
-
-    def _build_call_record_file_name(self):
-        if not self.callrecord:
-            return
-
         args = {
             'srcnum': self.srcnum,
             'dstnum': self.orig_dstnum,
@@ -127,7 +120,8 @@ class OutgoingFeatures(Handler):
             'base_context': self._context,
             'tenant_uuid': self._tenant_uuid,
         }
-        return self._call_recording_name_generator.generate(args)
+        callrecordfile = self._call_recording_name_generator.generate(args)
+        self._agi.set_variable(dialplan_variables.CALL_RECORD_FILE_NAME, callrecordfile)
 
     def _set_preprocess_subroutine(self):
         if self.outcall.preprocess_subroutine:

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -107,6 +107,9 @@ class OutgoingFeatures(Handler):
                 intfsuffix = ""
             self._agi.set_variable('%s%d' % (dialplan_variables.TRUNK_SUFFIX, i), intfsuffix)
 
+    def _set_record_enabled(self):
+        self._agi.set_variable('WAZO_CALL_RECORD_ENABLED', '1' if self.callrecord else '0')
+
     def _set_record_file_name(self):
         callrecordfile = self._build_call_record_file_name() or ''
         self._agi.set_variable(dialplan_variables.CALL_RECORD_FILE_NAME, callrecordfile)
@@ -159,6 +162,7 @@ class OutgoingFeatures(Handler):
         self._set_user_music_on_hold()
         self._set_caller_id()
         self._set_trunk_info()
+        self._set_record_enabled()
         self._set_record_file_name()
         self._set_preprocess_subroutine()
         self._set_hangup_ring_time()

--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -162,7 +162,7 @@ class TestUserFeatures(_BaseTestCase):
         userfeatures._user.callrecord = False
         userfeatures._context = 'default'
 
-        userfeatures._set_call_record_active()
+        userfeatures._set_call_record_enabled()
 
         self._agi.set_variable.assert_called_once_with('WAZO_CALL_RECORD_ENABLED', '0')
 

--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -156,6 +156,16 @@ class TestUserFeatures(_BaseTestCase):
         self.assertTrue(userfeatures._caller is not None)
         self.assertTrue(isinstance(userfeatures._caller, objects.User))
 
+    def test_set_call_record_enabled_doesnt_raise_when_caller_is_none(self):
+        userfeatures = UserFeatures(self._agi, self._cursor, self._args)
+        userfeatures._user = Mock()
+        userfeatures._user.callrecord = False
+        userfeatures._context = 'default'
+
+        userfeatures._set_call_record_active()
+
+        self._agi.set_variable.assert_called_once_with('WAZO_CALL_RECORD_ENABLED', '0')
+
     @patch('wazo_agid.handlers.userfeatures.context_dao')
     def test_set_call_recordfile_doesnt_raise_when_caller_is_none(self, context_dao):
         userfeatures = UserFeatures(self._agi, self._cursor, self._args)

--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -166,18 +166,6 @@ class TestUserFeatures(_BaseTestCase):
 
         self._agi.set_variable.assert_called_once_with('WAZO_CALL_RECORD_ENABLED', '0')
 
-    @patch('wazo_agid.handlers.userfeatures.context_dao')
-    def test_set_call_recordfile_doesnt_raise_when_caller_is_none(self, context_dao):
-        userfeatures = UserFeatures(self._agi, self._cursor, self._args)
-        userfeatures._user = Mock()
-        userfeatures._user.callrecord = True
-        userfeatures._context = 'default'
-
-        userfeatures._set_call_recordfile()
-
-        self._agi.set_variable.assert_called_once_with('XIVO_CALLRECORDFILE',
-                                                       NotEmptyStringMatcher())
-
     @patch('wazo_agid.handlers.userfeatures.extension_dao')
     @patch('wazo_agid.handlers.userfeatures.line_extension_dao')
     @patch('wazo_agid.handlers.userfeatures.line_dao')

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -331,7 +331,7 @@ class UserFeatures(Handler):
             'tenant_uuid': context_dao.get(self._context).tenant_uuid,
         }
         callrecordfile = self._call_recording_name_generator.generate(args)
-        self._agi.set_variable('XIVO_CALLRECORDFILE', callrecordfile)
+        self._agi.set_variable('__XIVO_CALLRECORDFILE', callrecordfile)
 
     def _set_music_on_hold(self):
         if self._user.musiconhold:

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -321,14 +321,6 @@ class UserFeatures(Handler):
         self._agi.set_variable('WAZO_CALL_RECORD_ENABLED', '1' if should_record else '0')
 
     def _set_call_recordfile(self):
-        callrecordfile = self._build_call_record_file_name() or ''
-        self._agi.set_variable('XIVO_CALLRECORDFILE', callrecordfile)
-
-    def _build_call_record_file_name(self):
-        should_record = self._user.callrecord or (self._caller and self._caller.callrecord)
-        if not should_record:
-            return
-
         args = {
             'srcnum': self._srcnum,
             'dstnum': self._dstnum,
@@ -338,7 +330,8 @@ class UserFeatures(Handler):
             'base_context': self._context,
             'tenant_uuid': context_dao.get(self._context).tenant_uuid,
         }
-        return self._call_recording_name_generator.generate(args)
+        callrecordfile = self._call_recording_name_generator.generate(args)
+        self._agi.set_variable('XIVO_CALLRECORDFILE', callrecordfile)
 
     def _set_music_on_hold(self):
         if self._user.musiconhold:

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -66,6 +66,7 @@ class UserFeatures(Handler):
         self._set_dial_action_congestion()
         self._set_dial_action_chanunavail()
         self._set_music_on_hold()
+        self._set_call_record_enabled()
         self._set_call_recordfile()
         self._set_preprocess_subroutine()
         self._set_mobile_number()
@@ -314,6 +315,10 @@ class UserFeatures(Handler):
         else:
             preprocess_subroutine = ""
         self._agi.set_variable('XIVO_USERPREPROCESS_SUBROUTINE', preprocess_subroutine)
+
+    def _set_call_record_enabled(self):
+        should_record = self._user.callrecord or (self._caller and self._caller.callrecord)
+        self._agi.set_variable('WAZO_CALL_RECORD_ENABLED', '1' if should_record else '0')
 
     def _set_call_recordfile(self):
         callrecordfile = self._build_call_record_file_name() or ''

--- a/wazo_agid/modules/call_recording.py
+++ b/wazo_agid/modules/call_recording.py
@@ -8,14 +8,6 @@ from wazo_agid import agid
 logger = logging.getLogger(__name__)
 
 
-class RecordingForbidden(Exception):
-
-    def __init__(self, user_id, firstname, lastname):
-        self.user_id = user_id
-        self.firstname = firstname
-        self.lastname = lastname
-
-
 def call_recording(agi, cursor, args):
     if agi.get_variable('WAZO_CALL_RECORD_ACTIVE') == '1':
         _disable_call_recording(agi, cursor, args)

--- a/wazo_agid/modules/call_recording.py
+++ b/wazo_agid/modules/call_recording.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+from wazo_agid import agid
+
+logger = logging.getLogger(__name__)
+
+
+class RecordingForbidden(Exception):
+
+    def __init__(self, user_id, firstname, lastname):
+        self.user_id = user_id
+        self.firstname = firstname
+        self.lastname = lastname
+
+
+def call_recording(agi, cursor, args):
+    if agi.get_variable('WAZO_CALL_RECORD_ACTIVE') == '1':
+        _disable_call_recording(agi, cursor, args)
+    else:
+        _enable_call_recording(agi, cursor, args)
+
+
+def _enable_call_recording(agi, cursor, args):
+    record_filename = agi.get_variable('XIVO_CALLRECORDFILE')
+    if not record_filename:
+        logger.error('Could not start recording: could not determine record file')
+        return
+
+    agi.appexec('MixMonitor', record_filename)
+    agi.set_variable('WAZO_CALL_RECORD_ACTIVE', '1')
+
+
+def _disable_call_recording(agi, cursor, args):
+    agi.appexec('StopMixMonitor')
+    agi.set_variable('WAZO_CALL_RECORD_ACTIVE', '0')
+
+
+agid.register(call_recording)


### PR DESCRIPTION
## user: separate call record enabled and file name


## outgoing: split record filename and enabled


## outgoing: always set XIVO_CALLRECORDFILE

Why:

* It is useful for online call recording
* It is not used to detect whether call recording should start now

## user: always set XIVO_CALLRECORDFILE


## user/outgoing: inherit XIVO_CALLRECORDFILE

Why:

* We want the filename to be passed down to called party and future
transfer destinations.
