### PR TITLE
record_caller: fix internal test

### DIFF
--- a/wazo_agid/modules/call_recording.py
+++ b/wazo_agid/modules/call_recording.py
@@ -31,7 +31,7 @@ def record_caller(agi, cursor, args):
     if not caller:
         return
 
-    is_internal = agi.get_variable(dialplan_variables.CALL_ORIGIN) == 'intern'
+    is_internal = agi.get_variable(dialplan_variables.CALL_ORIGIN) != 'extern'
     should_record = caller and (
         (is_internal and caller.call_record_outgoing_internal_enabled)
         or (not is_internal and caller.call_record_outgoing_external_enabled)


### PR DESCRIPTION
the call origin variable is set to 'extern' on incoming calls, otherwise it is
not set when calling internally