### PR TITLE
cenference: add a cel event with the conference name

### DIFF
--- a/integration_tests/suite/helpers/agid.py
+++ b/integration_tests/suite/helpers/agid.py
@@ -128,6 +128,12 @@ class AgidClient(_BaseAgidClient):
             variables, commands = self._process_communicate()
         return variables, commands
 
+    def incoming_conference_set_features(self, variables):
+        with self._connect():
+            self._send_handler('incoming_conference_set_features')
+            variables, commands = self._process_communicate(variables)
+        return variables, commands
+
     def incoming_user_set_features(self, variables):
         with self._connect():
             self._send_handler('incoming_user_set_features')

--- a/integration_tests/suite/helpers/database.py
+++ b/integration_tests/suite/helpers/database.py
@@ -90,6 +90,15 @@ class DatabaseQueries(object):
         yield ItemInserter(session, tenant_uuid=TENANT_UUID)
         session.commit()
 
+    def insert_conference(self, **kwargs):
+        with self.inserter() as inserter:
+            conference = inserter.add_conference(**kwargs)
+            return {
+                'id': conference.id,
+                'name': conference.name,
+                'tenant_uuid': conference.tenant_uuid,
+            }
+
     def insert_user_line_extension(self, **kwargs):
         with self.inserter() as inserter:
             ule = inserter.add_user_line_with_exten(**kwargs)

--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -214,9 +214,26 @@ class TestHandlers(IntegrationTest):
     def test_incoming_agent_set_features(self):
         pass
 
-    @pytest.mark.skip('NotImplemented')
     def test_incoming_conference_set_features(self):
-        pass
+        name = 'My Conference'
+        with self.db.queries() as queries:
+            conference = queries.insert_conference(name=name)
+
+        variables = {
+            'XIVO_DSTID': conference['id'],
+        }
+        recv_vars, recv_cmds = self.agid.incoming_conference_set_features(variables)
+
+        bridge_profile = 'xivo-bridge-profile-{}'.format(conference['id'])
+        user_profile = 'xivo-user-profile-{}'.format(conference['id'])
+        assert recv_cmds['FAILURE'] is False
+        assert recv_vars['WAZO_CONFBRIDGE_ID'] == str(conference['id'])
+        assert recv_vars['WAZO_CONFBRIDGE_TENANT_UUID'] == conference['tenant_uuid']
+        assert recv_vars['WAZO_CONFBRIDGE_BRIDGE_PROFILE'] == bridge_profile
+        assert recv_vars['WAZO_CONFBRIDGE_USER_PROFILE'] == user_profile
+        assert recv_vars['WAZO_CONFBRIDGE_MENU'] == 'xivo-default-user-menu'
+        assert recv_vars['WAZO_CONFBRIDGE_PREPROCESS_SUBROUTINE'] == ''
+        assert recv_cmds['EXEC CELGenUserEvent'] == 'WAZO_CONFERENCE, NAME: {}'.format(name)
 
     @pytest.mark.skip('NotImplemented')
     def test_incoming_did_set_features(self):

--- a/wazo_agid/modules/incoming_conference_set_features.py
+++ b/wazo_agid/modules/incoming_conference_set_features.py
@@ -38,6 +38,7 @@ def incoming_conference_set_features(agi, cursor, args):
     agi.set_variable('WAZO_CONFBRIDGE_USER_PROFILE', user_profile)
     agi.set_variable('WAZO_CONFBRIDGE_MENU', menu)
     agi.set_variable('WAZO_CONFBRIDGE_PREPROCESS_SUBROUTINE', conference.preprocess_subroutine or '')
+    agi.appexec('CELGenUserEvent', 'WAZO_CONFERENCE, NAME: {}'.format(conference.name or ''))
 
 
 agid.register(incoming_conference_set_features)


### PR DESCRIPTION
this event is consumed by wazo-call-logd to set the destination name