### PR TITLE
WAZO-2837 Remove six as dep since it is no longer needed in xivo-lib-python

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          wazo-confd-client-python3,
          wazo-dird-client-python3,
          xivo-lib-python-python3,
-         xivo-libdao
+         xivo-libdao-python3
 Provides: xivo-agid
 Conflicts: xivo-utils (<= 18.09~20180808.174753.0834260.deb9), xivo-agid
 Replaces: xivo-agid

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -2,7 +2,6 @@ psycopg2-binary
 pyhamcrest
 pytest
 pyyaml  # from xivo-lib-python
-six  # from xivo-lib-python
 sqlalchemy==1.2.18
 
 https://github.com/wazo-platform/xivo-dao/archive/master.zip

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-mock
 pyhamcrest
 pytest

--- a/wazo_agid/tests/test_agid.py
+++ b/wazo_agid/tests/test_agid.py
@@ -1,17 +1,17 @@
 # Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import mock
-import unittest
+from unittest import TestCase
+from unittest.mock import Mock
 from wazo_agid.agid import Handler
 
 
-class TestHandler(unittest.TestCase):
+class TestHandler(TestCase):
     def test_handler_setup_calls_setup_function(self):
-        setup_function = mock.Mock()
+        setup_function = Mock()
         fake_cursor = object()
 
-        handler = Handler("foo", setup_function, mock.Mock())
+        handler = Handler("foo", setup_function, Mock())
         handler.setup(fake_cursor)
 
         setup_function.assert_called_once_with(fake_cursor)


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/113
Depends-on: https://github.com/wazo-platform/xivo-dao/pull/187