### PR TITLE
Removed convert_pre_dial_handler

### DIFF
--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 import re
 import pytest
@@ -361,16 +361,15 @@ class TestHandlers(IntegrationTest):
         assert recv_vars['XIVO_FWD_SCHEDULE_OUT_ACTIONARG1'] == '1'
         assert recv_vars['XIVO_FWD_SCHEDULE_OUT_ACTIONARG2'] == 'arg2'
 
-    def test_convert_pre_dial_handler(self):
+    def test_ignore_b_option(self):
         variables = {
             'XIVO_CALLOPTIONS': 'Xb(foobaz^s^1)B(foobar^s^1)',
         }
 
-        recv_vars, recv_cmds = self.agid.convert_pre_dial_handler(variables=variables)
+        recv_vars, recv_cmds = self.agid.ignore_b_option(variables=variables)
 
         assert recv_cmds['FAILURE'] is False
         assert recv_vars['XIVO_CALLOPTIONS'] == 'XB(foobar^s^1)'
-        assert recv_vars['PUSH(_WAZO_PRE_DIAL_HANDLERS,|)'] == 'foobaz,s,1'
 
     def test_fwdundoall(self):
         with self.db.queries() as queries:

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ changedir = integration_tests
 passenv =
     MANAGE_DB_DIR
     WAZO_TEST_DOCKER_OVERRIDE_EXTRA
+    DOCKER_HOST
 commands =
     make test-setup
     pytest -v {posargs}

--- a/wazo_agid/modules/ignore_b_option.py
+++ b/wazo_agid/modules/ignore_b_option.py
@@ -9,9 +9,10 @@ from wazo_agid.dialplan_variables import CALL_OPTIONS
 B_REGEX = re.compile(r'b\(([\-_0-9A-Za-z]+)\^?.*?\)')
 
 
-# This AGI was added in 21.01 to avoid breaking user written dialplan
-# This AGI and all of it's calls should be deleted in a reasonable amount of time 22.01?
-def convert_pre_dial_handler(agi, cursor, args):
+def ignore_b_option(agi, cursor, args):
+    """
+    handler to detect and warn about usage of b option
+    """
     call_options = agi.get_variable(CALL_OPTIONS)
     if not call_options:
         return
@@ -23,14 +24,15 @@ def convert_pre_dial_handler(agi, cursor, args):
     to_remove = match.group(0)
     to_stack = match.group(1)
 
-    agi.verbose(f'WARNING: deprecated dialplan option detected {to_stack}')
-    agi.verbose('Wazo pre-dial handlers should be used instead')
+    agi.verbose(
+        f'WARNING: deprecated usage of dialplan b option detected with subroutine: {to_stack}'
+    )
+    agi.verbose(
+        'Option will be ignored. Wazo pre-dial handlers should be used instead.'
+    )
 
     pruned_call_options = call_options.replace(to_remove, '')
     agi.set_variable(CALL_OPTIONS, pruned_call_options)
 
-    new_handler = f'{to_stack},s,1'
-    agi.set_variable('PUSH(_WAZO_PRE_DIAL_HANDLERS,|)', new_handler)
 
-
-agid.register(convert_pre_dial_handler)
+agid.register(ignore_b_option)

--- a/wazo_agid/modules/tests/test_ignore_b_option.py
+++ b/wazo_agid/modules/tests/test_ignore_b_option.py
@@ -8,17 +8,17 @@ from unittest.mock import Mock, call
 
 from wazo_agid.fastagi import FastAGI
 
-from ..convert_pre_dial_handler import convert_pre_dial_handler
+from ..ignore_b_option import ignore_b_option
 
 
-class TestConvertPreDialHandler(unittest.TestCase):
+class TestIgnoreBOption(unittest.TestCase):
     def setUp(self):
         self.agi = Mock(FastAGI)
 
     def test_no_call_options(self):
         self.agi.get_variable.return_value = ''
 
-        convert_pre_dial_handler(self.agi, Mock(), Mock())
+        ignore_b_option(self.agi, Mock(), Mock())
 
         self.agi.set_variable.assert_not_called()
 
@@ -26,7 +26,7 @@ class TestConvertPreDialHandler(unittest.TestCase):
         variables = {'XIVO_CALLOPTIONS': 'XB(foobar^s^1)'}
         self.agi.get_variable.side_effect = variables.get
 
-        convert_pre_dial_handler(self.agi, Mock(), Mock())
+        ignore_b_option(self.agi, Mock(), Mock())
 
         self.agi.set_variable.assert_not_called()
 
@@ -36,12 +36,11 @@ class TestConvertPreDialHandler(unittest.TestCase):
         }
         self.agi.get_variable.side_effect = variables.get
 
-        convert_pre_dial_handler(self.agi, Mock(), Mock())
+        ignore_b_option(self.agi, Mock(), Mock())
 
         assert_that(
             self.agi.set_variable.call_args_list,
             contains_inanyorder(
                 call('XIVO_CALLOPTIONS', 'XB(foobar^s^1)'),
-                call('PUSH(_WAZO_PRE_DIAL_HANDLERS,|)', 'foobaz,s,1'),
             ),
         )


### PR DESCRIPTION
https://wazo-dev.atlassian.net/browse/WAZO-2854

* Note: failed to run integration tests
  ```
  wazo_test_helpers.asset_launching_test_case.NoSuchService: No such service: agid
  ```
  But issue most probably unrelated to this change.