### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, black, linters
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -43,7 +43,7 @@ application-import-names = wazo_agid
 ignore = E203, W503
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
@@ -52,5 +52,5 @@ passenv =
 commands =
     make test-setup
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
     make


### PR DESCRIPTION
changes:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals