### PR TITLE
Add dependency on sqlalchemy-utils for dao

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -3,6 +3,7 @@ pyhamcrest
 pytest
 pyyaml==5.3.1  # from xivo-lib-python
 sqlalchemy==1.3.22
+sqlalchemy-utils==0.36.8  # from xivo-dao
 
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ pytz==2021.1
 pyyaml==5.3.1  # from xivo-lib-python
 requests==2.25.1
 sqlalchemy==1.3.22  # from xivo-dao
+sqlalchemy-utils==0.36.8  # from xivo-dao
 stevedore==3.2.2  # from wazo-lib-rest-client
 unidecode==1.2.0


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-dao/pull/207