### PR TITLE
Pull request for WP-1065-fix-sharing-device-state

### DIFF
--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -414,7 +414,7 @@ class TestHandlers(IntegrationTest):
             line_2 = queries.insert_line(typeval=user['id'])
             queries.insert_user_line(user['id'], line_2['id'])
 
-        shared_lines = f'sccp/{line_1["name"]}&pjsip/{line_2["name"]}'
+        shared_lines = f'SCCP/{line_1["name"]}&PJSIP/{line_2["name"]}'
         variables = {
             f'HINT({user["uuid"]}@usersharedlines)': shared_lines,
             f'PJSIP_ENDPOINT({line_2["name"]},webrtc)': 'no',
@@ -425,7 +425,7 @@ class TestHandlers(IntegrationTest):
         )
 
         assert recv_cmds['FAILURE'] is False
-        assert recv_vars['WAZO_USER_INTERFACES'] == f'sccp/{line_1["name"]}&contact'
+        assert recv_vars['WAZO_USER_INTERFACES'] == f'SCCP/{line_1["name"]}&contact'
 
     def test_group_answered_call(self):
         with self.db.queries() as queries:

--- a/wazo_agid/modules/get_user_interfaces.py
+++ b/wazo_agid/modules/get_user_interfaces.py
@@ -35,7 +35,7 @@ class _UserLine:
 
     def _find_matching_interfaces(self, endpoint: str) -> Generator[str, None, None]:
         protocol, name = endpoint.split('/', 1)
-        if protocol == 'pjsip':
+        if protocol == 'PJSIP':
             contacts = build_sip_interface(self._agi, self._user_uuid, name)
             yield from contacts.split('&')
         else:

--- a/wazo_agid/modules/tests/test_get_user_interfaces.py
+++ b/wazo_agid/modules/tests/test_get_user_interfaces.py
@@ -21,7 +21,7 @@ from ..get_user_interfaces import (
 class TestUserLine(TestCase):
 
     hints = {
-        'abc@usersharedlines': 'pjsip/one&sccp/two&custom/i1/55555555&pjsip/two&pjsip/three',
+        'abc@usersharedlines': 'PJSIP/one&SCCP/two&CUSTOM/i1/55555555&PJSIP/two&PJSIP/three',
     }
 
     contacts = {
@@ -55,8 +55,8 @@ class TestUserLine(TestCase):
         assert_that(
             user_line.interfaces,
             contains_inanyorder(
-                'sccp/two',
-                'custom/i1/55555555',
+                'SCCP/two',
+                'CUSTOM/i1/55555555',
                 'one-1',
                 'one-2',
                 'two-1',


### PR DESCRIPTION
## hint: always use uppercase

why: when user sharing device state from asterisk, device state is
shared with case sensitive and all custom hints must be in uppercase to
be updated correctly

note: sharing device state is used for horizontal scaling

## test: fix styling issue

why: is preferable to always use uppercase for device technology. It
avoid issue with sharing device state between asterisk