### PR TITLE
Pull request for flaky-integration-test

### DIFF
--- a/integration_tests/suite/helpers/agid.py
+++ b/integration_tests/suite/helpers/agid.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import re
 import socket
 from contextlib import contextmanager
@@ -13,6 +14,8 @@ CMD_STATUS_REGEX = r'^Status: OK$'
 CMD_VERBOSE_REGEX = r'^VERBOSE "(.*)" (\d)$'
 CMD_AGI_FAIL = r'.*agi_fail.*'
 CMD_GENERIC_REGEX = r'^(.*) "(.*)"'
+
+logger = logging.getLogger(__name__)
 
 
 class AGIFailException(Exception):

--- a/integration_tests/suite/helpers/agid.py
+++ b/integration_tests/suite/helpers/agid.py
@@ -7,6 +7,7 @@ import logging
 import re
 import socket
 from contextlib import contextmanager
+from typing import Generator
 
 GET_VARIABLE_REGEX = r'^GET VARIABLE "(.*)"$'
 SET_VARIABLE_REGEX = r'^SET VARIABLE "(.*)" "(.*)"$'
@@ -44,7 +45,9 @@ class _BaseAgidClient:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             self._socket = s
             self._socket.connect((self._host, self._port))
+
             yield
+
             self._socket.close()
             self._socket = None  # type: ignore[assignment]
 
@@ -71,17 +74,25 @@ class _BaseAgidClient:
         fragment = fragment + '\n'
         self._socket.send(fragment.encode('utf-8'))
 
+    def _readlines(self) -> Generator[str, None, None]:
+        recved = self._socket.recv(1024)
+
+        while recved:
+            if b'\n' not in recved:
+                return
+            recved_line, recved = recved.split(b'\n', 1)
+
+            yield recved_line.decode('utf-8')
+
+            recved += self._socket.recv(1024)
+
     def _process_communicate(self, variables=None):
         received_variables: dict[str, str] = {}
         received_commands: dict[str, list[str] | bool | str] = {
             'VERBOSE': [],
             'FAILURE': False,
         }
-        while True:
-            data = self._socket.recv(1024).decode('utf-8')
-            if not data:
-                break
-
+        for data in self._readlines():
             result = re.search(CMD_AGI_FAIL, data)
             if result:
                 received_commands['FAILURE'] = True

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import logging
+
 from pathlib import Path
 
 from .agentd import AgentdMockClient
@@ -18,6 +20,9 @@ from wazo_test_helpers.asset_launching_test_case import (
     WrongClient,
 )
 from wazo_test_helpers import until
+
+DEFAULT_LOG_FORMAT = '%(asctime)s [%(process)d] (%(levelname)s) (%(name)s): %(message)s'
+logging.basicConfig(format=DEFAULT_LOG_FORMAT)
 
 
 class BaseAssetLaunchingHelper(AbstractAssetLaunchingHelper):


### PR DESCRIPTION
## integration tests: configure logging


## integration tests: fix fake AGI client receiving two lines

Why:

* When AGI returned two lines too closely together, the fake AGI client
  was dropping the second line, leading to an error at the next read
  operation