### PR TITLE
WAZO-3603: add P-Asserted-Identity header on anonymous call

### DIFF
--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -897,10 +897,8 @@ def test_outgoing_user_set_features(base_asset: BaseAssetLaunchingHelper):
     assert recv_vars['XIVO_PATH_ID'] == str(call['id'])
     assert recv_vars['WAZO_CALL_RECORD_SIDE'] == 'caller'
     assert recv_vars['CALLERID(pres)'] == 'prohib'
-    assert (
-        recv_vars['_WAZO_OUTBOUND_PAI']
-        == '\\"Anonymous\\" <sip:123456@anonymous.invalid>'
-    )
+    assert recv_vars['WAZO_OUTGOING_ANONYMOUS_CALL'] == '1'
+    assert recv_vars['_WAZO_OUTCALL_PAI_NUMBER'] == '123456'
 
 
 def test_meeting_user(base_asset: BaseAssetLaunchingHelper):

--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -867,7 +867,7 @@ def test_outgoing_user_set_features(base_asset: BaseAssetLaunchingHelper):
             outcallid=call['id'], trunkfeaturesid=trunk['id']
         )
 
-        dial_pattern = queries.insert_dial_pattern(typeid=call['id'])
+        dial_pattern = queries.insert_dial_pattern(callerid='123456', typeid=call['id'])
         extension = queries.insert_extension(type='outcall', typeval=call['id'])
 
     variables = {
@@ -896,8 +896,11 @@ def test_outgoing_user_set_features(base_asset: BaseAssetLaunchingHelper):
     assert recv_vars['XIVO_PATH'] == 'outcall'
     assert recv_vars['XIVO_PATH_ID'] == str(call['id'])
     assert recv_vars['WAZO_CALL_RECORD_SIDE'] == 'caller'
-    assert recv_vars['CALLERID(name-pres)'] == 'prohib'
-    assert recv_vars['CALLERID(num-pres)'] == 'prohib'
+    assert recv_vars['CALLERID(pres)'] == 'prohib'
+    assert (
+        recv_vars['_WAZO_OUTBOUND_PAI']
+        == '\\"Anonymous\\" <sip:123456@anonymous.invalid>'
+    )
 
 
 def test_meeting_user(base_asset: BaseAssetLaunchingHelper):

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -100,10 +100,12 @@ class OutgoingFeatures(Handler):
                 '%s: _set_caller_id: using anonymous caller ID',
                 self._agi.env['agi_channel'],
             )
-            pai_header = f'"Anonymous" <sip:{self.outcall.callerid}@anonymous.invalid>'
-
             self._agi.set_variable('CALLERID(pres)', 'prohib')
-            self._agi.set_variable('_WAZO_OUTBOUND_PAI', pai_header)
+            self._agi.set_variable('WAZO_OUTGOING_ANONYMOUS_CALL', '1')
+            if self.outcall.callerid:
+                _, pai_tel = objects.CallerID.parse(self.outcall.callerid)
+                if pai_tel:
+                    self._agi.set_variable('_WAZO_OUTCALL_PAI_NUMBER', pai_tel)
         else:
             logger.debug(
                 '%s: _set_caller_id: using user outgoing caller ID',

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2006-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -100,14 +100,20 @@ class OutgoingFeatures(Handler):
                 '%s: _set_caller_id: using anonymous caller ID',
                 self._agi.env['agi_channel'],
             )
-            self._agi.set_variable('CALLERID(name-pres)', 'prohib')
-            self._agi.set_variable('CALLERID(num-pres)', 'prohib')
+            pai_header = f'tel:{self.outcall.callerid}'
+
+            self._agi.set_variable('CALLERID(pres)', 'prohib')
+            self._agi.set_variable('_WAZO_OUTBOUND_PAI', pai_header)
+            self._schedule_predial_subroutine('wazo-outcall-set-anonymous')
         else:
             logger.debug(
                 '%s: _set_caller_id: using user outgoing caller ID',
                 self._agi.env['agi_channel'],
             )
             objects.CallerID.set(self._agi, self.user.outcallerid)
+
+    def _schedule_predial_subroutine(self, subroutine: str) -> None:
+        self._agi.execute('EXEC', 'Gosub', f'wazo-add-pre-dial-hook,s,1({subroutine})')
 
     def _set_trunk_info(self) -> None:
         for i, trunk in enumerate(self.outcall.trunks):

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -104,20 +104,12 @@ class OutgoingFeatures(Handler):
 
             self._agi.set_variable('CALLERID(pres)', 'prohib')
             self._agi.set_variable('_WAZO_OUTBOUND_PAI', pai_header)
-            self._schedule_predial_subroutine('wazo-outcall-set-anonymous')
         else:
             logger.debug(
                 '%s: _set_caller_id: using user outgoing caller ID',
                 self._agi.env['agi_channel'],
             )
             objects.CallerID.set(self._agi, self.user.outcallerid)
-
-    def _schedule_predial_subroutine(self, subroutine: str) -> None:
-        extension = 'wazo-add-pre-dial-hook'
-        context = 's'
-        priority = '1'
-        args = self._agi._quote(f'{extension},{context},{priority}({subroutine})')
-        self._agi.execute('EXEC', 'Gosub', args)
 
     def _set_trunk_info(self) -> None:
         for i, trunk in enumerate(self.outcall.trunks):

--- a/wazo_agid/handlers/outgoingfeatures.py
+++ b/wazo_agid/handlers/outgoingfeatures.py
@@ -100,7 +100,7 @@ class OutgoingFeatures(Handler):
                 '%s: _set_caller_id: using anonymous caller ID',
                 self._agi.env['agi_channel'],
             )
-            pai_header = f'tel:{self.outcall.callerid}'
+            pai_header = f'"Anonymous" <sip:{self.outcall.callerid}@anonymous.invalid>'
 
             self._agi.set_variable('CALLERID(pres)', 'prohib')
             self._agi.set_variable('_WAZO_OUTBOUND_PAI', pai_header)
@@ -113,7 +113,11 @@ class OutgoingFeatures(Handler):
             objects.CallerID.set(self._agi, self.user.outcallerid)
 
     def _schedule_predial_subroutine(self, subroutine: str) -> None:
-        self._agi.execute('EXEC', 'Gosub', f'wazo-add-pre-dial-hook,s,1({subroutine})')
+        extension = 'wazo-add-pre-dial-hook'
+        context = 's'
+        priority = '1'
+        args = self._agi._quote(f'{extension},{context},{priority}({subroutine})')
+        self._agi.execute('EXEC', 'Gosub', args)
 
     def _set_trunk_info(self) -> None:
         for i, trunk in enumerate(self.outcall.trunks):

--- a/wazo_agid/handlers/tests/test_outgoingfeatures.py
+++ b/wazo_agid/handlers/tests/test_outgoingfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -238,8 +238,8 @@ class TestOutgoingFeatures(unittest.TestCase):
         self.outgoing_features._set_caller_id()
 
         expected_calls = [
-            call('CALLERID(name-pres)', 'prohib'),
-            call('CALLERID(num-pres)', 'prohib'),
+            call('CALLERID(pres)', 'prohib'),
+            call('_WAZO_OUTBOUND_PAI', '"Anonymous" <sip:@anonymous.invalid>'),
         ]
         self.assertEqual(self._agi.set_variable.call_args_list, expected_calls)
         self.assertFalse(mock_set_caller_id.called)
@@ -257,8 +257,8 @@ class TestOutgoingFeatures(unittest.TestCase):
         self.outgoing_features._set_caller_id()
 
         expected_calls = [
-            call('CALLERID(name-pres)', 'prohib'),
-            call('CALLERID(num-pres)', 'prohib'),
+            call('CALLERID(pres)', 'prohib'),
+            call('_WAZO_OUTBOUND_PAI', '"Anonymous" <sip:27857218@anonymous.invalid>'),
         ]
         self.assertEqual(self._agi.set_variable.call_args_list, expected_calls)
         self.assertFalse(mock_set_caller_id.called)

--- a/wazo_agid/handlers/tests/test_outgoingfeatures.py
+++ b/wazo_agid/handlers/tests/test_outgoingfeatures.py
@@ -239,7 +239,7 @@ class TestOutgoingFeatures(unittest.TestCase):
 
         expected_calls = [
             call('CALLERID(pres)', 'prohib'),
-            call('_WAZO_OUTBOUND_PAI', '"Anonymous" <sip:@anonymous.invalid>'),
+            call('WAZO_OUTGOING_ANONYMOUS_CALL', '1'),
         ]
         self.assertEqual(self._agi.set_variable.call_args_list, expected_calls)
         self.assertFalse(mock_set_caller_id.called)
@@ -258,7 +258,8 @@ class TestOutgoingFeatures(unittest.TestCase):
 
         expected_calls = [
             call('CALLERID(pres)', 'prohib'),
-            call('_WAZO_OUTBOUND_PAI', '"Anonymous" <sip:27857218@anonymous.invalid>'),
+            call('WAZO_OUTGOING_ANONYMOUS_CALL', '1'),
+            call('_WAZO_OUTCALL_PAI_NUMBER', '27857218'),
         ]
         self.assertEqual(self._agi.set_variable.call_args_list, expected_calls)
         self.assertFalse(mock_set_caller_id.called)


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-config/pull/110

If user's callerid is anonymous, sets the SIP Header `P-Asserted-Identity` to outcall's callerid using the `tel:` schema so trunks allow anonymous' `from` in invites.  

The PJSIP endpoint parameter `send_pai` doesn't work here because it sends the internal callerid, which the trunk doesnt know and will most probably reject 

