### PR TITLE
mypy: use default import following policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ python_version = "3.10"
 show_error_codes = true
 check_untyped_defs = true
 warn_unused_configs = true
-follow_imports = "skip"
 ignore_missing_imports = true
 
 [tool.black]


### PR DESCRIPTION
Why:

* This option makes pre-commit miss some typing errors