### PR TITLE
jenkinsfile: do not use cache when building image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     }
     stage('Docker build') {
       steps {
-        sh "docker build -t wazoplatform/${JOB_NAME}:latest ."
+        sh "docker build --no-cache -t wazoplatform/${JOB_NAME}:latest ."
       }
     }
     stage('Docker publish') {


### PR DESCRIPTION
why: wazo libraries are not versioned