### PR TITLE
Narrow autoprov devices discovery

### DIFF
--- a/wazo_agid/modules/provision.py
+++ b/wazo_agid/modules/provision.py
@@ -29,7 +29,7 @@ def _do_provision(client: ConfdClient, provcode: str, ip: str) -> None:
 
 
 def _get_device(client: ConfdClient, ip: str) -> dict[str, Any]:
-    response = client.devices.list(ip=ip, recurse=True)
+    response = client.devices.list(ip=ip, search='autoprov', recurse=True)
     if response['total'] != 1:
         raise Exception(f"Device with ip {ip} not found")
     return response['items'][0]

--- a/wazo_agid/modules/tests/test_provision.py
+++ b/wazo_agid/modules/tests/test_provision.py
@@ -40,7 +40,9 @@ class TestDoProvision(unittest.TestCase):
 
         self.provision("123456", "127.0.0.1")
 
-        self.client.devices.list.assert_called_once_with(ip="127.0.0.1", search="autoprov", recurse=True)
+        self.client.devices.list.assert_called_once_with(
+            ip="127.0.0.1", search="autoprov", recurse=True
+        )
         self.client.lines.list.assert_called_once_with(
             provisioning_code="123456", recurse=True
         )

--- a/wazo_agid/modules/tests/test_provision.py
+++ b/wazo_agid/modules/tests/test_provision.py
@@ -40,7 +40,7 @@ class TestDoProvision(unittest.TestCase):
 
         self.provision("123456", "127.0.0.1")
 
-        self.client.devices.list.assert_called_once_with(ip="127.0.0.1", recurse=True)
+        self.client.devices.list.assert_called_once_with(ip="127.0.0.1", search="autoprov", recurse=True)
         self.client.lines.list.assert_called_once_with(
             provisioning_code="123456", recurse=True
         )


### PR DESCRIPTION
Hello,

When we provision devices using the _Provision Extension_ method, there's no issue when stack is on local network, because all devices have a unique IP.
When devices are NATed, for example when stack is public, registering devices from a specific site using the _Provision Extension_ method works for the very first device, then fails, as subsequent devices come with the same IP.

This PR then narrows devices discovery, limiting it to devices in _autoprov_ status.
As a result, provisioning NATed devices from a specific site one by one, using  the _Provision Extension_ method, will work.

Many thanks 👍

Depends-On: https://github.com/wazo-platform/wazo-confd/pull/502
Re-edit of #90.