### PR TITLE
[WP-1740] userfeatures: add __ before simultcalls variables

### DIFF
--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -64,7 +64,7 @@ def test_incoming_user_set_features_with_dstid(base_asset: BaseAssetLaunchingHel
     assert recv_vars['WAZO_DST_TENANT_UUID'] == user['tenant_uuid']
     assert recv_vars['WAZO_INTERFACE'] == 'contact'
     assert recv_vars['WAZO_CALLOPTIONS'] == ''
-    assert recv_vars['WAZO_CALLEE_SIMULTCALLS'] == str(user['simultcalls'])
+    assert recv_vars[f'__{dv.CALLEE_SIMULTCALLS}'] == str(user['simultcalls'])
     assert recv_vars['WAZO_RINGSECONDS'] == str(user['ringseconds'])
     assert recv_vars['WAZO_ENABLEDND'] == str(user['enablednd'])
     assert recv_vars[dv.ENABLEVOICEMAIL] == str(user['enablevoicemail'])

--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -123,7 +123,10 @@ class TestUserFeatures(_BaseTestCase):
             user_init.assert_called_with(
                 self._agi, self._cursor, int(self._variables['WAZO_USERID'])
             )
-            self._agi.set_variable.assert_called_once_with('WAZO_CALLER_SIMULTCALLS', 5)
+            self._agi.set_variable.assert_called_once_with(
+                f'__{dv.CALLER_SIMULTCALLS}',
+                5,
+            )
         self.assertTrue(userfeatures._caller is not None)
 
     def test_set_call_record_enabled_incoming_external_call(self):

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -107,7 +107,9 @@ class UserFeatures(Handler):
                 self._caller = None
 
             if self._caller:
-                self._agi.set_variable(dv.CALLER_SIMULTCALLS, self._caller.simultcalls)
+                self._agi.set_variable(
+                    f'__{dv.CALLER_SIMULTCALLS}', self._caller.simultcalls
+                )
 
     def _set_line(self) -> None:
         if self._dstid:
@@ -453,7 +455,9 @@ class UserFeatures(Handler):
             self._agi.set_variable(name, '')
 
     def _set_callee_simultcalls(self):
-        return self._agi.set_variable(dv.CALLEE_SIMULTCALLS, self._user.simultcalls)
+        return self._agi.set_variable(
+            f'__{dv.CALLEE_SIMULTCALLS}', self._user.simultcalls
+        )
 
     def _set_enablednd(self):
         self._agi.set_variable('WAZO_ENABLEDND', self._user.enablednd)


### PR DESCRIPTION
Why: otherwise they are not defined in the transfer channels